### PR TITLE
Always handle asset manifests as UTF-8 encoded

### DIFF
--- a/lib/capistrano/recipes/deploy/assets.rb
+++ b/lib/capistrano/recipes/deploy/assets.rb
@@ -24,6 +24,7 @@ end
 # Parses manifest and returns array of uncompressed and compressed asset filenames with and without digests
 # "Intelligently" determines format of string - supports YAML and JSON
 def parse_manifest(str)
+  str = str.force_encoding('UTF-8')
   assets_hash = str[0,1] == '{' ? JSON.parse(str)['assets'] : YAML.load(str)
 
   assets_hash.to_a.flatten.map {|a| [a, "#{a}.gz"] }.flatten


### PR DESCRIPTION
When a manifest file contains UTF-8 encoded strings, capistrano 2 fails when executing `deploy:assets:clean_expired' with an encoding error.
This is due to the fact that the received string is interpreted as ASCII.

Manifest files should always be UTF-8 encoded (JSON, ...), so we can enforce the encoding to UTF-8.
